### PR TITLE
Automatically create the default log directory on Linux if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ On Linux:
     systemctl --user stop clipper.service
     systemctl --user disable clipper.service
     sudo rm /usr/local/bin/clipper
+    rm -r ~/.config/clipper
 
 To kill a manually-launched instance of Clipper, just hit Control+C in the terminal where it is running.
 

--- a/clipper.go
+++ b/clipper.go
@@ -35,6 +35,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"os/user"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -208,6 +209,14 @@ func mergeSettings() {
 		settings.Logfile = config.Logfile
 	} else {
 		settings.Logfile = defaults.Logfile
+		if runtime.GOOS == "linux" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				log.Fatal(err)
+			}
+			configDir := path.Join(home, ".config/clipper/logs")
+			os.MkdirAll(configDir, 0700)
+		}
 	}
 	if flags.Port.provided || config.Port.provided {
 		if isPath(settings.Address.value) {

--- a/clipper.go
+++ b/clipper.go
@@ -35,7 +35,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"os/user"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -210,11 +209,7 @@ func mergeSettings() {
 	} else {
 		settings.Logfile = defaults.Logfile
 		if runtime.GOOS == "linux" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				log.Fatal(err)
-			}
-			configDir := path.Join(home, ".config/clipper/logs")
+			configDir := pathByExpandingTildeInPath(filepath.Dir(defaults.Logfile.value))
 			os.MkdirAll(configDir, 0700)
 		}
 	}

--- a/clipper.go
+++ b/clipper.go
@@ -208,10 +208,6 @@ func mergeSettings() {
 		settings.Logfile = config.Logfile
 	} else {
 		settings.Logfile = defaults.Logfile
-		if runtime.GOOS == "linux" {
-			configDir := pathByExpandingTildeInPath(filepath.Dir(defaults.Logfile.value))
-			os.MkdirAll(configDir, 0700)
-		}
 	}
 	if flags.Port.provided || config.Port.provided {
 		if isPath(settings.Address.value) {
@@ -270,6 +266,10 @@ func main() {
 	// Merge flags -> config -> defaults.
 	mergeSettings()
 
+	if runtime.GOOS == "linux" {
+		configDir := expandPath(filepath.Dir(settings.Logfile.value))
+		os.MkdirAll(configDir, 0700)
+	}
 	expandedPath := expandPath(settings.Logfile.value)
 	outfile, err := os.OpenFile(expandedPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {


### PR DESCRIPTION
When installed on Linux clipper will crash on startup when run without any arguments as it can't create a new log file in the default logs directory, which doesn't exist by default:

```
$ clipper
clipper: 2020/06/15 12:11:02 open /home/daniel/.config/clipper/clipper.json: no such file or directory
clipper: 2020/06/15 12:11:02 open /home/daniel/.config/clipper/logs/clipper.log: no such file or directory
```
This PR fixes that by recursively creating `~/.config/clipper/logs` if it doesn't exist, and if the user hasn't requested a different log file location.