### PR TITLE
Update systemd service

### DIFF
--- a/contrib/linux/systemd-service/clipper.service
+++ b/contrib/linux/systemd-service/clipper.service
@@ -1,15 +1,15 @@
 [Unit]
 Description=Clipper ~ Clipboard proxy
+Documentation=https://github.com/wincent/clipper
 
 [Service]
 Environment=DISPLAY=:0
-ExecStart=/usr/local/bin/clipper
+# Fix logging to stderr
+# https://unix.stackexchange.com/a/401396/101415
+ExecStart=/bin/bash -o pipefail -c '{ clipper --logfile /dev/stderr 2>&1 >&3 3>&- | cat >&2 3>&-; } 3>&1'
 Restart=always
 # Restart service after 10 seconds if service crashes
 RestartSec=10
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=clipper
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
This addresses the following issues:

- `StandardOutput=syslog` and `StandardError=syslog` are deprecated
- when logfile is set to `/dev/stdout` or `/dev/stderr` in the config the service does not start (which is required for the journal - see next item)
- The service's journal is not written to (`journalctl --user -u clipper.service`)

Edit: I also added a `Documentation` link to this repo.